### PR TITLE
Add CaregiverRole enum and update UserCaregiver relationship

### DIFF
--- a/src/main/java/com/project/demo/logic/entity/caregiver/CaregiverRole.java
+++ b/src/main/java/com/project/demo/logic/entity/caregiver/CaregiverRole.java
@@ -1,0 +1,7 @@
+package com.project.demo.logic.entity.caregiver;
+
+public enum CaregiverRole {
+    CAREGIVER,
+    RELATIVE,
+    DOCTOR
+}

--- a/src/main/java/com/project/demo/logic/entity/caregiver/UserCaregiver.java
+++ b/src/main/java/com/project/demo/logic/entity/caregiver/UserCaregiver.java
@@ -18,13 +18,14 @@ public class UserCaregiver {
     @JoinColumn(name = "caregiver_id")
     private Caregiver caregiver;
 
+    @Enumerated(EnumType.STRING)
     @Column(length = 50)
-    private String relationship;
+    private CaregiverRole relationship;
 
     public UserCaregiver() {
     }
 
-    public UserCaregiver(Integer id, User user, Caregiver caregiver, String relationship) {
+    public UserCaregiver(Integer id, User user, Caregiver caregiver, CaregiverRole relationship) {
         this.id = id;
         this.user = user;
         this.caregiver = caregiver;
@@ -55,11 +56,11 @@ public class UserCaregiver {
         this.caregiver = caregiver;
     }
 
-    public String getRelationship() {
+    public CaregiverRole getRelationship() {
         return relationship;
     }
 
-    public void setRelationship(String relationship) {
+    public void setRelationship(CaregiverRole relationship) {
         this.relationship = relationship;
     }
 }


### PR DESCRIPTION

Esta solicitud de extracción introduce una nueva enumeración «CaregiverRole» para reemplazar el tipo «String» utilizado anteriormente para el campo «relationship» en la clase «UserCaregiver». Este cambio mejora la seguridad de tipos y garantiza que solo se puedan asignar roles predefinidos al campo «relationship».

### Introducción de la enumeración `CaregiverRole`:
* Se agregó una nueva enumeración `CaregiverRole` en `CaregiverRole.java` con roles predefinidos: `CAREGIVER`, `RELATIVE` y `DOCTOR`. (`src/main/java/com/project/demo/logic/entity/caregiver/CaregiverRole.java`, [src/main/java/com/project/demo/logic/entity/caregiver/CaregiverRole.javaR1-R7](diffhunk://#diff-103c2743db929c17a9d949a3a03d60259d8df4c1464d3f73089527fc066c06d0R1-R7))

### Actualizaciones a la clase `UserCaregiver`:
Se actualizó el campo "relación" en "UserCaregiver" para usar la enumeración "CaregiverRole" en lugar de un "String". Esto incluye cambios en su tipo, métodos getter y setter, así como en el constructor. (`src/main/java/com/project/demo/logic/entity/caregiver/UserCaregiver.java`, [[1]](diffhunk://#diff-925c786b53fd0c23a0c8eba7694bf2b6cb902083d7877e523fd9560e3c5f097bR21-R28) [[2]](diffhunk://#diff-925c786b53fd0c23a0c8eba7694bf2b6cb902083d7877e523fd9560e3c5f097bL58-R63)