### PR TITLE
Conexión del juego puzzle al backend

### DIFF
--- a/src/main/java/com/project/demo/logic/entity/game/GameSeeder.java
+++ b/src/main/java/com/project/demo/logic/entity/game/GameSeeder.java
@@ -25,7 +25,7 @@ public class GameSeeder implements ApplicationListener<ContextRefreshedEvent> {
     /**
      * Método que se ejecuta al iniciar la aplicación.
      * Este método se encarga de sembrar los juegos iniciales en la base de datos
-     * @param contextRefreshedEvent
+     * @param contextRefreshedEvent el evento que indica que el contexto de la aplicación ha sido inicializado o refrescado
      */
 
     @Override

--- a/src/main/java/com/project/demo/logic/entity/game/GameSeeder.java
+++ b/src/main/java/com/project/demo/logic/entity/game/GameSeeder.java
@@ -1,0 +1,40 @@
+package com.project.demo.logic.entity.game;
+
+import com.project.demo.logic.entity.game.repository.GameRepository;
+import com.project.demo.logic.entity.settings.LevelEnum;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Seeder para inicializar los juegos en la base de datos.
+ * Se ejecuta al iniciar la aplicación y crea los registros necesarios
+ * para todos los tipos de juego disponibles.
+ */
+@Component
+public class GameSeeder implements CommandLineRunner {
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (gameRepository.count() == 0) {
+            seedGames();
+        }
+    }
+
+    /**
+     * Crea los registros iniciales de juegos para todos los tipos disponibles.
+     */
+    private void seedGames() {
+        for (GameTypeEnum gameType : GameTypeEnum.values()) {
+            if (!gameRepository.findFirstByGameType(gameType).isPresent()) {
+                Game game = new Game();
+                game.setGameType(gameType);
+                game.setLevel(null);
+                gameRepository.save(game);
+            }
+        }
+    }
+}

--- a/src/main/java/com/project/demo/logic/entity/game/GameSeeder.java
+++ b/src/main/java/com/project/demo/logic/entity/game/GameSeeder.java
@@ -4,6 +4,9 @@ import com.project.demo.logic.entity.game.repository.GameRepository;
 import com.project.demo.logic.entity.settings.LevelEnum;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
@@ -12,16 +15,22 @@ import org.springframework.stereotype.Component;
  * para todos los tipos de juego disponibles.
  */
 @Component
-public class GameSeeder implements CommandLineRunner {
+@Order(3)
+@org.springframework.context.annotation.Profile("!test")
+public class GameSeeder implements ApplicationListener<ContextRefreshedEvent> {
 
     @Autowired
     private GameRepository gameRepository;
 
+    /**
+     * Método que se ejecuta al iniciar la aplicación.
+     * Este método se encarga de sembrar los juegos iniciales en la base de datos
+     * @param contextRefreshedEvent
+     */
+
     @Override
-    public void run(String... args) throws Exception {
-        if (gameRepository.count() == 0) {
-            seedGames();
-        }
+    public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
+        this.seedGames();
     }
 
     /**

--- a/src/main/java/com/project/demo/logic/entity/game/repository/GameRepository.java
+++ b/src/main/java/com/project/demo/logic/entity/game/repository/GameRepository.java
@@ -3,6 +3,8 @@ package com.project.demo.logic.entity.game.repository;
 import com.project.demo.logic.entity.game.Game;
 import com.project.demo.logic.entity.game.GameTypeEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -10,5 +12,5 @@ import java.util.Optional;
  * Proporciona métodos para realizar operaciones CRUD sobre los juegos.
  */
 public interface GameRepository extends JpaRepository<Game, Integer> {
-    Optional<Game> findByGameType(GameTypeEnum gameType);
+    Optional<Game> findFirstByGameType(GameTypeEnum gameType);
 }

--- a/src/main/java/com/project/demo/rest/game/GameController.java
+++ b/src/main/java/com/project/demo/rest/game/GameController.java
@@ -63,9 +63,11 @@ public class GameController {
         String currentUserName = authentication.getName();
         User user = userRepository.findByEmail(currentUserName)
                 .orElseThrow(() -> new RuntimeException("User not found"));
-
         score.setUser(user);
         score.setDate(new Date());
+        var game = gameRepository.findFirstByGameType(score.getGameType())
+                .orElseThrow(() -> new RuntimeException("Game not found for type: " + score.getGameType()));
+        score.setGame(game);
 
         // Si es un puzzle, calcular la puntuación automáticamente
         if (score.getGameType() == GameTypeEnum.PUZZLE) {


### PR DESCRIPTION
Esta solicitud de extracción introduce un sembrador de base de datos para inicializar los registros de juego y actualiza la forma en que los juegos se recuperan y se asocian con las puntuaciones. Los cambios garantizan que cada tipo de juego se sembra al iniciar la aplicación y que las puntuaciones hagan referencia a la entidad de juego correcta en la base de datos.


* Se agregó un nuevo componente `GameSeeder` que se ejecuta al iniciar la aplicación (excepto en el perfil de prueba) para crear registros iniciales de `Game` para todos los tipos de juego disponibles, si aún no existen. * Se modificó la interfaz `GameRepository`: se reemplazó `findByGameType` por `findFirstByGameType` para recuperar solo un juego por tipo, en consonancia con la lógica de siembra y el uso en otros entornos.

**Actualización de la lógica de guardado de puntuaciones:**

* Se actualizó el método `saveScore` en `GameController` para obtener la entidad `Game` correcta usando `findFirstByGameType` y asociarla con el nuevo puntaje, asegurando la integridad referencial y la consistencia.